### PR TITLE
New Method + Cleanup

### DIFF
--- a/card/mockCard.go
+++ b/card/mockCard.go
@@ -337,6 +337,10 @@ func (c *MockCard) IdentifyCard(nonce []byte) (cardPubKey *ecdsa.PublicKey, card
 	return c.IdentityPubKey, cardSig, nil
 }
 
+func (c *MockCard) IdentifyPostedPhononNonce() (nonce uint64, err error) {
+	return c.nonce, nil
+}
+
 func (c *MockCard) InstallCertificate(signKeyFunc func([]byte) ([]byte, error)) error {
 	var err error
 	rawCardCert, err := cert.CreateCardCertificate(c.IdentityPubKey, signKeyFunc)

--- a/card/phononCommandSet.go
+++ b/card/phononCommandSet.go
@@ -415,6 +415,12 @@ func (cs *PhononCommandSet) IdentifyCard(nonce []byte) (cardPubKey *ecdsa.Public
 	return cardPubKey, cardSig, nil
 }
 
+func (cs *PhononCommandSet) IdentifyPostedPhononNonce() (nonce uint64, err error){
+	log.Debug("sending IDENTIFY_POSTED_PHONON_NONCE command")
+	log.Debug("POST PHONONS ONLY AVAIALABLE FOR MOCK CARDS RIGHT NOW")
+	return 0, nil
+}
+
 func (cs *PhononCommandSet) VerifyPIN(pin string) error {
 	log.Debug("sending VERIFY_PIN command")
 	cmd := NewCommandVerifyPIN(pin)

--- a/model/card.go
+++ b/model/card.go
@@ -14,6 +14,7 @@ type PhononCard interface {
 	OpenSecureConnection() error
 	Init(pin string) error
 	IdentifyCard(nonce []byte) (cardPubKey *ecdsa.PublicKey, cardSig *util.ECDSASignature, err error)
+	IdentifyPostedPhononNonce() (nonce uint64, err error)
 	VerifyPIN(pin string) error
 	ChangePIN(pin string) error
 	CreatePhonon(curveType CurveType) (keyIndex uint16, pubKey PhononPubKey, err error)

--- a/orchestrator/session.go
+++ b/orchestrator/session.go
@@ -256,6 +256,9 @@ func (s *Session) DestroyPhonon(keyIndex uint16) (privKey *ecdsa.PrivateKey, err
 }
 
 func (s *Session) IdentifyCard(nonce []byte) (cardPubKey *ecdsa.PublicKey, cardSig *util.ECDSASignature, err error) {
+	if !s.verified() {
+		return nil, card.ErrPINNotEntered
+	}
 	s.ElementUsageMtex.Lock()
 	defer s.ElementUsageMtex.Unlock()
 
@@ -266,6 +269,9 @@ func (s *Session) IdentifyPostedPhononNonce() (nonce uint64, err error) {
 	if !s.verified() {
 		return 0, card.ErrPINNotEntered
 	}
+	s.ElementUsageMtex.Lock()
+	defer s.ElementUsageMtex.Unlock()
+	
 	return s.cs.IdentifyPostedPhononNonce()
 }
 

--- a/orchestrator/session.go
+++ b/orchestrator/session.go
@@ -257,7 +257,7 @@ func (s *Session) DestroyPhonon(keyIndex uint16) (privKey *ecdsa.PrivateKey, err
 
 func (s *Session) IdentifyCard(nonce []byte) (cardPubKey *ecdsa.PublicKey, cardSig *util.ECDSASignature, err error) {
 	if !s.verified() {
-		return nil, card.ErrPINNotEntered
+		return nil, nil, card.ErrPINNotEntered
 	}
 	s.ElementUsageMtex.Lock()
 	defer s.ElementUsageMtex.Unlock()
@@ -271,7 +271,7 @@ func (s *Session) IdentifyPostedPhononNonce() (nonce uint64, err error) {
 	}
 	s.ElementUsageMtex.Lock()
 	defer s.ElementUsageMtex.Unlock()
-	
+
 	return s.cs.IdentifyPostedPhononNonce()
 }
 

--- a/orchestrator/session.go
+++ b/orchestrator/session.go
@@ -262,6 +262,13 @@ func (s *Session) IdentifyCard(nonce []byte) (cardPubKey *ecdsa.PublicKey, cardS
 	return s.cs.IdentifyCard(nonce)
 }
 
+func (s *Session) IdentifyPostedPhononNonce() (nonce uint64, err error) {
+	if !s.verified() {
+		return 0, card.ErrPINNotEntered
+	}
+	return s.cs.IdentifyPostedPhononNonce()
+}
+
 func (s *Session) InitCardPairing(receiverCert cert.CardCertificate) ([]byte, error) {
 	if !s.verified() {
 		return nil, card.ErrPINNotEntered

--- a/repl/post.go
+++ b/repl/post.go
@@ -100,3 +100,17 @@ func identifyCard(c *ishell.Context) {
   c.Println(util.ECCPubKeyToHexString(cardPubKey))
   return
 }
+
+func identifyPostedPhononNonce(c *ishell.Context) {
+  if ready := checkActiveCard(c); !ready {
+    return
+  }
+
+  nonce, err  := activeCard.IdentifyPostedPhononNonce()
+  if err != nil {
+		c.Println("error getting posted phonon nonce: ", err)
+		return
+	}
+  c.Println("Current posted phonon nonce: ", nonce)
+  c.Println("Next avaialble posted phonon nonce: ", nonce+1)
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -62,6 +62,11 @@ func Start() {
 		Help: "Get active card's public key as hex",
 	})
 	shell.AddCmd(&ishell.Cmd{
+		Name: "identifyPostedPhononNonce",
+		Func: identifyPostedPhononNonce,
+		Help: "Get the card's next posted phonon nonce",
+	})
+	shell.AddCmd(&ishell.Cmd{
 		Name: "changePin",
 		Func: changeCardPIN,
 		Help: "Change the active card's PIN",


### PR DESCRIPTION
- Added a new method `identifyPostedPhononNonce`.  We can deprecate or merge this get into a different method, but for now we needed the ability to see the nonce. 
- Requiring cards be unlocked before `identifyCard` and `identifyPostedPhononNonce` can be called. Also, including the `s.ElementUsageMtex.Lock()` code block.