### PR TITLE
Branded Phonons

### DIFF
--- a/card/mockCard.go
+++ b/card/mockCard.go
@@ -653,6 +653,11 @@ func (c *MockCard) CreatePhonon(curveType model.CurveType) (keyIndex uint16, pub
 }
 
 func (c *MockCard) SetDescriptor(phonon *model.Phonon) error {
+
+	if (storedPhonon.CurrencyType == 5) {
+		return fmt.Errorf("setDescriptor is not allowed for branded phonons %d", phonon.KeyIndex)
+	}
+
 	if int(phonon.KeyIndex) >= len(c.Phonons) || c.Phonons[phonon.KeyIndex].deleted {
 		return fmt.Errorf("no phonon at index %d", phonon.KeyIndex)
 	}

--- a/card/mockCard.go
+++ b/card/mockCard.go
@@ -654,7 +654,7 @@ func (c *MockCard) CreatePhonon(curveType model.CurveType) (keyIndex uint16, pub
 
 func (c *MockCard) SetDescriptor(phonon *model.Phonon) error {
 
-	if (storedPhonon.CurrencyType == 5) {
+	if (phonon.CurrencyType == 5) {
 		return fmt.Errorf("setDescriptor is not allowed for branded phonons %d", phonon.KeyIndex)
 	}
 

--- a/card/mockCard.go
+++ b/card/mockCard.go
@@ -652,11 +652,24 @@ func (c *MockCard) CreatePhonon(curveType model.CurveType) (keyIndex uint16, pub
 	return index, newp.PubKey, nil
 }
 
-func (c *MockCard) SetDescriptor(phonon *model.Phonon) error {
+func (c *MockCard) CreatePhononSpecial(curveType model.CurveType, p *model.Phonon) (keyIndex uint16, pubKey model.PhononPubKey, err error) {
 
-	if (phonon.CurrencyType == 5) {
-		return fmt.Errorf("setDescriptor is not allowed for branded phonons %d", phonon.KeyIndex)
+	if (p.CurrencyType != 5) {
+		return 0, nil, fmt.Errorf("this currency type is not eligible for special creation %d", p.CurrencyType)
 	}
+
+	index, pubkey, nil := c.CreatePhonon(curveType)
+	storedPhonon := &c.Phonons[index].Phonon
+
+	storedPhonon.ExtendedTLV = p.ExtendedTLV
+	storedPhonon.Denomination = p.Denomination
+	storedPhonon.CurrencyType = p.CurrencyType
+
+	return index, pubkey, nil
+}
+
+
+func (c *MockCard) SetDescriptor(phonon *model.Phonon) error {
 
 	if int(phonon.KeyIndex) >= len(c.Phonons) || c.Phonons[phonon.KeyIndex].deleted {
 		return fmt.Errorf("no phonon at index %d", phonon.KeyIndex)
@@ -666,6 +679,10 @@ func (c *MockCard) SetDescriptor(phonon *model.Phonon) error {
 
 	if (storedPhonon.CurrencyType == 4) {
 		return fmt.Errorf("flexible phonons cannot be updated after creation %d", phonon.KeyIndex)
+	}
+
+	if (storedPhonon.CurrencyType == 5) {
+		return fmt.Errorf("branded phonons cannot be updated after creation %d", phonon.KeyIndex)
 	}
 
 	storedPhonon.SchemaVersion = phonon.SchemaVersion

--- a/card/phononCommandSet.go
+++ b/card/phononCommandSet.go
@@ -478,6 +478,13 @@ func (cs *PhononCommandSet) CreatePhonon(curveType model.CurveType) (keyIndex ui
 	return keyIndex, pubKey, nil
 }
 
+func (cs *PhononCommandSet) CreatePhononSpecial(curveType model.CurveType, p *model.Phonon) (keyIndex uint16, pubKey model.PhononPubKey, err error) {
+	log.Debug("sending CREATE_PHONON_SPECIAL command")
+	log.Debug("CREATE PHONON SPECIAL ONLY AVAIALABLE FOR MOCK CARDS RIGHT NOW")
+
+	return 0, nil, nil
+}
+
 //Common error code checks for commands that deal with the phonon table
 //CREATE_PHONON, LIST_PHONONS, DESTROY_PHONON, etc.
 func checkPhononTableErrors(sw uint16) error {

--- a/model/card.go
+++ b/model/card.go
@@ -18,6 +18,7 @@ type PhononCard interface {
 	VerifyPIN(pin string) error
 	ChangePIN(pin string) error
 	CreatePhonon(curveType CurveType) (keyIndex uint16, pubKey PhononPubKey, err error)
+	CreatePhononSpecial(curveType CurveType, phonon *Phonon) (keyIndex uint16, pubKey PhononPubKey, err error)
 	SetDescriptor(phonon *Phonon) error
 	ListPhonons(currencyType CurrencyType, lessThanValue uint64, greaterThanValue uint64, continuation bool) ([]*Phonon, error)
 	GetPhononPubKey(keyIndex uint16, crv CurveType) (pubkey PhononPubKey, err error)

--- a/model/currencytype_string.go
+++ b/model/currencytype_string.go
@@ -13,11 +13,12 @@ func _() {
 	_ = x[Ethereum-2]
 	_ = x[Native-3]
 	_ = x[Flexible-4]
+	_ = x[Branded-5]
 }
 
-const _CurrencyType_name = "UnspecifiedBitcoinEthereumNativeFlexible"
+const _CurrencyType_name = "UnspecifiedBitcoinEthereumNativeFlexibleBranded"
 
-var _CurrencyType_index = [...]uint8{0, 11, 18, 26, 32, 40}
+var _CurrencyType_index = [...]uint8{0, 11, 18, 26, 32, 40, 47}
 
 func (i CurrencyType) String() string {
 	if i >= CurrencyType(len(_CurrencyType_index)-1) {

--- a/model/phonon.go
+++ b/model/phonon.go
@@ -118,6 +118,7 @@ const (
 	Ethereum    CurrencyType = 0x0002
 	Native      CurrencyType = 0x0003
 	Flexible      CurrencyType = 0x0004
+	Branded      CurrencyType = 0x0005
 )
 
 type CurveType uint8

--- a/orchestrator/session.go
+++ b/orchestrator/session.go
@@ -218,6 +218,14 @@ func (s *Session) CreatePhonon() (keyIndex uint16, pubkey model.PhononPubKey, er
 	return s.cs.CreatePhonon(model.Secp256k1)
 }
 
+func (s *Session) CreatePhononSpecial(currencyType model.CurrencyType, denomination model.Denomination, extendedTLV tlv.TLVList) (err error) {
+		log.Debug("initiating orchestrator CreatePhononSpecial")
+		log.Debug(currencyType)
+		log.Debug(denomination)
+		log.Debug(extendedTLV)
+		return nil
+}
+
 func (s *Session) SetDescriptor(p *model.Phonon) error {
 	if !s.verified() {
 		return card.ErrPINNotEntered

--- a/orchestrator/session.go
+++ b/orchestrator/session.go
@@ -218,12 +218,15 @@ func (s *Session) CreatePhonon() (keyIndex uint16, pubkey model.PhononPubKey, er
 	return s.cs.CreatePhonon(model.Secp256k1)
 }
 
-func (s *Session) CreatePhononSpecial(currencyType model.CurrencyType, denomination model.Denomination, extendedTLV tlv.TLVList) (err error) {
-		log.Debug("initiating orchestrator CreatePhononSpecial")
-		log.Debug(currencyType)
-		log.Debug(denomination)
-		log.Debug(extendedTLV)
-		return nil
+func (s *Session) CreatePhononSpecial(p *model.Phonon) (keyIndex uint16, pubkey model.PhononPubKey, err error) {
+
+	if !s.verified() {
+		return 0, nil, card.ErrPINNotEntered
+	}
+	s.ElementUsageMtex.Lock()
+	defer s.ElementUsageMtex.Unlock()
+
+	return s.cs.CreatePhononSpecial(model.Secp256k1, p)
 }
 
 func (s *Session) SetDescriptor(p *model.Phonon) error {

--- a/repl/branded.go
+++ b/repl/branded.go
@@ -1,0 +1,45 @@
+package repl
+
+import (
+  "math/big"
+	"strconv"
+  "github.com/GridPlus/phonon-client/tlv"
+  "github.com/GridPlus/phonon-client/model"
+
+  log "github.com/sirupsen/logrus"
+	ishell "github.com/abiosoft/ishell/v2"
+)
+
+func createBrandedPhonon(c *ishell.Context, currencyType model.CurrencyType) {
+  log.Debug("creating branded phonon")
+
+  if ready := checkActiveCard(c); !ready {
+		return
+	}
+
+  c.Println("What is source private key hex for this branded phonon?")
+  // Example for Testing:
+  // 03a0b699905d81fed15c814725f0e09bd275921f4b0657b364e4a80183eb0ebb
+  sourcePrivKeyInput := c.ReadLine()
+
+  extendedTLV := tlv.TLVList{}
+  sourceTLV, err := model.TagFlexSourcePublicKey(sourcePrivKeyInput)
+  if err != nil {
+    c.Println("could not create tlv for source private key", err)
+    return
+  }
+  extendedTLV = append(extendedTLV, sourceTLV)
+
+  c.Println("What is the value of this branded phonon?")
+  valueInput := c.ReadLine()
+
+  value, err := strconv.ParseUint(valueInput, 10, 0)
+  if err != nil {
+    c.Println("value could not be parse: ", err)
+    return
+  }
+  denomination, err := model.NewDenomination(big.NewInt(int64(value)))
+
+  activeCard.CreatePhononSpecial(currencyType, denomination, extendedTLV)
+
+}

--- a/repl/branded.go
+++ b/repl/branded.go
@@ -40,6 +40,12 @@ func createBrandedPhonon(c *ishell.Context, currencyType model.CurrencyType) {
   }
   denomination, err := model.NewDenomination(big.NewInt(int64(value)))
 
-  activeCard.CreatePhononSpecial(currencyType, denomination, extendedTLV)
+  p := &model.Phonon{
+    CurrencyType: currencyType,
+    Denomination: denomination,
+    ExtendedTLV: extendedTLV,
+  }
+
+  activeCard.CreatePhononSpecial(p)
 
 }

--- a/repl/phonons.go
+++ b/repl/phonons.go
@@ -22,6 +22,25 @@ func createPhonon(c *ishell.Context) {
 	c.Println("Public Key: ", pubKey)
 }
 
+func createPhononSpecial(c *ishell.Context) {
+	if ready := checkActiveCard(c); !ready {
+		return
+	}
+
+	specialTypes := []string{"Branded"}
+
+	selection := c.MultiChoice(specialTypes, "please select an available card")
+
+	if selection == -1 {
+		c.Println("no special type selected")
+	} else if selection == 0 {
+
+		currencyType := model.CurrencyType(5)
+		createBrandedPhonon(c, currencyType)
+	}
+
+}
+
 func listPhonons(c *ishell.Context) {
 	if ready := checkActiveCard(c); !ready {
 		return

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -82,6 +82,11 @@ func Start() {
 		Help: "Create a new phonon key on active card",
 	})
 	shell.AddCmd(&ishell.Cmd{
+		Name: "createSpecial",
+		Func: createPhononSpecial,
+		Help: "Create a new phonon key with special properties",
+	})
+	shell.AddCmd(&ishell.Cmd{
 		Name: "flexPhonons",
 		Func: flexPhonons,
 		Help: "Swap value using flexible phonons",


### PR DESCRIPTION
`Branding: process in which a mark, usually a symbol or ornamental pattern, is burned into the skin of a living person or animal`

This is what I was trying to explain last night.  Flexible phonons have two unique characteristics: 1) the ability to have its description set on creation and made thereafter immutable (by disallowing setDescriptor) 2) the ability to flex value between sibling flexible phonons.  Flexible Phonons are both, but the first unique characteristic is interesting in its own right.

I give you Branded Phonons - basically the same thing as a Flexible Phonon except they cannot flex value.  I'm thinking we create a `createPhononSpecial` method which basically is create and setDescriptor in one.

Accept these changes, and I will proceed to build the Flexible Phonon flow updates to my changes. 